### PR TITLE
merge from master to fork

### DIFF
--- a/src/examples/auth/README.md
+++ b/src/examples/auth/README.md
@@ -7,12 +7,13 @@
 ### 1. Device Type Registration
 (The device type registration can also be done using the IoT Cockpit.)
 
-* Before registering and authenticating devices with client certificates a corresponding device type using client certificate authentication must be registered. ```<rdms_host>``` specifies the application url of your IoT Services Remote Device Management Service (RDMS), e.g. ```https://iotrdmsiotservices-<account_name>.hana.ondemand.com```.
+* Before registering and authenticating devices with client certificates a corresponding device type using client certificate authentication must be registered. ```<rdms_host>``` specifies the application url of your IoT Services Remote Device Management Service (RDMS), e.g. ```https://iotrdmsiotservices-<account_name>.hana.ondemand.com```. 
 
 ```
 $ curl --header "Content-Type: application/json" --basic --user "<username>" --data "{\"name\": \"Device Type 1\",\"authentication\": {\"type\": \"clientCertificate\"}}" https://<rdms_host>/com.sap.iotservices.dms/v2/api/deviceTypes
 ```
 
+* Optional: In case you need to set a proxy, please specify ```--proxy <proxyhost>:<port>``` when using the ```curl``` command.
 * The request body specifies the device type ```name``` and authentication ```type```:
 ```
 {
@@ -127,7 +128,7 @@ An optional company name []:.
 * Finally the registered device must be authenticated, i.e. to receive the device certificate. Again the  acquired device type certificate must be attached to the HTTPS connection. It will then be used during the initial SSL handshake as client certificate.
 
 ```
-$ curl --header "Content-Type: application/json" --cert-type P12 --cert ./<device_type_certificate>.p12:<secret> --data "{\"type\": \"clientCertificate\",\"csr\": \"MIIC6jCCAdICAQAwgYsxCzAJBgNVB…\"}\" https://<rdms_cert_host>/com.sap.iotservices.dms/v2/api/devices/<deviceId>/authentication
+$ curl --header "Content-Type: application/json" --cert-type P12 --cert ./<device_type_certificate>.p12:<secret> --data "{\"type\": \"clientCertificate\",\"csr\": \"MIIC6jCCAdICAQAwgYsxCzAJBgNVB…\"}" https://<rdms_cert_host>/com.sap.iotservices.dms/v2/api/devices/<deviceId>/authentication
 ```
 
 * The request body entails the authentication ```type``` and the previously generated base64-encoded ```csr```:


### PR DESCRIPTION
* Instructions for client certificate authentication

Instructions for client certificate authentication using curl and
openssl.

* Fixed wrong curl command

* MQTT over WS example with Client Certificate Authentication

Extended the MQTT over WS example (script and config) with Client
Certificate Authentication

* Fix relative link

* Improved description and openssl commands

* cURL command fixing (escaping characters) for Windows

* Optional proxy settings

* [Fix] Optional proxy settings